### PR TITLE
Increase width of filesize diff text

### DIFF
--- a/tasks/sizediff.js
+++ b/tasks/sizediff.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
 					diff = prettyBytes(diff);
 				}
 
-				grunt.log.writetableln([12, 12, 55], [
+				grunt.log.writetableln([12, 14, 55], [
 					lpad(prettyBytes(current), ' ', 10),
 					lpad(chalk[color](diff ? '(' + diff + ')' : '(-)'), ' ', 10),
 					item.filename


### PR DESCRIPTION
Addresses instances where the text would sometimes wrap:

Before:

![image](https://cloud.githubusercontent.com/assets/371943/15517478/ef771f3c-21c5-11e6-8c95-0277d34a7aeb.png)

After:

![image](https://cloud.githubusercontent.com/assets/371943/15517483/fb14d956-21c5-11e6-9e1d-a79dbfa0d68c.png)
